### PR TITLE
Memoize the style to prevent useless rendering

### DIFF
--- a/src/hooks/makeStyle.ts
+++ b/src/hooks/makeStyle.ts
@@ -8,8 +8,12 @@ export interface Style { [key: string]: ViewStyle | TextStyle | ImageStyle }
 
 export const makeStyle = <T extends Style>(applyTheme: (theme: Theme) => T): (() => T) => (): T => {
     const { theme } = useTheme();
-    const styles = applyTheme(theme);
-    return StyleSheet.create(styles);
+
+    return useMemo(() =>  {
+      const styles = applyTheme(theme);
+
+     return StyleSheet.create(styles)
+    }, [theme, applyTheme]);
 };
 
 export default makeStyle;


### PR DESCRIPTION
In one of our project, we found out that the `StyleSheet` was created multiple time during the lifecycle of a component and cause many render. By memoizing the style, we prevent useless rendering that could impact the performance in React-Native